### PR TITLE
Add hidden parameter to opcodes

### DIFF
--- a/module/ILAssembler.psm1
+++ b/module/ILAssembler.psm1
@@ -6,7 +6,10 @@ if ($PSVersionTable.PSVersion.Major -eq 5) {
 
 $throwOutsideAssembler = {
     [CmdletBinding()]
-    param()
+    param(
+        [Parameter(ValueFromRemainingArguments, DontShow)]
+        [object[]] $Arguments
+    )
     end {
         $PSCmdlet.ThrowTerminatingError(
             [Management.Automation.ErrorRecord]::new(


### PR DESCRIPTION
This way calling an opcode outside of an IL block won't cause a parameter binding exception if the opcode has an operand type.