### PR TITLE
Allow anonymous method signatures

### DIFF
--- a/src/ILAssembler/AstExtensions.cs
+++ b/src/ILAssembler/AstExtensions.cs
@@ -109,6 +109,13 @@ namespace ILAssembler
                 expectedType);
         }
 
+        public static ParseException ErrorElementNotSupported(this Ast ast)
+        {
+            return ErrorElementNotSupported(
+                ast.Extent,
+                ast.GetType().Name);
+        }
+
         public static ParseException ErrorElementNotSupported(this Ast ast, string displayName)
         {
             return ErrorElementNotSupported(ast.Extent, displayName);

--- a/src/ILAssembler/HashCode.cs
+++ b/src/ILAssembler/HashCode.cs
@@ -1,0 +1,44 @@
+namespace ILAssembler
+{
+    internal static class HashCode
+    {
+#if CORE
+        public static int Combine<T1>(T1 value1) => System.HashCode.Combine(value1);
+        public static int Combine<T1, T2>(T1 value1, T2 value2) => System.HashCode.Combine(value1, value2);
+        public static int Combine<T1, T2, T3>(T1 value1, T2 value2, T3 value3) => System.HashCode.Combine(value1, value2, value3);
+#else
+        public static int Combine<T1>(T1 value1)
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = (hash * 23) + (value1?.GetHashCode() ?? 0);
+                return hash;
+            }
+        }
+
+        public static int Combine<T1, T2>(T1 value1, T2 value2)
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = (hash * 23) + (value1?.GetHashCode() ?? 0);
+                hash = (hash * 23) + (value2?.GetHashCode() ?? 0);
+                return hash;
+            }
+        }
+
+        public static int Combine<T1, T2, T3>(T1 value1, T2 value2, T3 value3)
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = (hash * 23) + (value1?.GetHashCode() ?? 0);
+                hash = (hash * 23) + (value2?.GetHashCode() ?? 0);
+                hash = (hash * 23) + (value3?.GetHashCode() ?? 0);
+                return hash;
+            }
+        }
+#endif
+    }
+}

--- a/src/ILAssembler/ILAssembler.csproj
+++ b/src/ILAssembler/ILAssembler.csproj
@@ -7,6 +7,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5' ">
+    <DefineConstants>$(DefineConstants);CORE</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />

--- a/src/ILAssembler/IReadOnlyListExtensions.cs
+++ b/src/ILAssembler/IReadOnlyListExtensions.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace ILAssembler
+{
+    internal static class IReadOnlyListExtensions
+    {
+        public static ReadOnlyListSegment<T> Slice<T>(this IReadOnlyList<T> source, int start)
+        {
+            return new ReadOnlyListSegment<T>(
+                source,
+                start,
+                source.Count - start);
+        }
+
+        public static ReadOnlyListSegment<T> Slice<T>(this IReadOnlyList<T> source, int start, int length)
+        {
+            return new ReadOnlyListSegment<T>(
+                source,
+                start,
+                length);
+        }
+    }
+}

--- a/src/ILAssembler/MemberSignatureParser.cs
+++ b/src/ILAssembler/MemberSignatureParser.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Management.Automation.Language;
 
 namespace ILAssembler
@@ -8,7 +10,7 @@ namespace ILAssembler
 
         protected TypedIdentifier? DeclaringType { get; private set; }
 
-        protected bool IsStatic { get; private set; }
+        protected bool IsStatic { get; set; }
 
         protected TypedIdentifier? ReturnType { get; private set; }
 
@@ -76,6 +78,11 @@ namespace ILAssembler
             IsStatic = memberExpressionAst.Static;
         }
 
+        protected virtual void VisitAnonymousSignature(ExpressionAst expressionAst)
+        {
+            throw expressionAst.ErrorUnexpectedType("MemberExpression");
+        }
+
         protected virtual void HandleUnresolvableSubject(ExpressionAst ast)
         {
             throw ast.GetParseError(
@@ -109,6 +116,20 @@ namespace ILAssembler
                     invokeMemberExpressionAst.Extent.StartScriptPosition.ToScriptExtent());
 
                 invokeMemberExpressionAst.Visit(_parent);
+            }
+
+            public override void VisitArrayExpression(ArrayExpressionAst arrayExpressionAst)
+            {
+                _parent.ReturnType = GetSignatureAndReset(
+                    arrayExpressionAst.Extent.StartScriptPosition.ToScriptExtent());
+                _parent.VisitAnonymousSignature(arrayExpressionAst);
+            }
+
+            public override void VisitParenExpression(ParenExpressionAst parenExpressionAst)
+            {
+                _parent.ReturnType = GetSignatureAndReset(
+                    parenExpressionAst.Extent.StartScriptPosition.ToScriptExtent());
+                _parent.VisitAnonymousSignature(parenExpressionAst);
             }
         }
     }

--- a/src/ILAssembler/ReadOnlyListSegment.cs
+++ b/src/ILAssembler/ReadOnlyListSegment.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace ILAssembler
+{
+    internal readonly struct ReadOnlyListSegment<T> : IReadOnlyList<T>, IEquatable<ReadOnlyListSegment<T>>
+    {
+        private readonly IReadOnlyList<T> _source;
+
+        private readonly int _offset;
+
+        public ReadOnlyListSegment(IReadOnlyList<T> source, int offset, int length)
+        {
+            _source = source;
+            _offset = offset;
+            Count = length;
+        }
+
+        public IReadOnlyList<T> Source => _source ?? Array.Empty<T>();
+
+        public T this[int index] => Source[index + _offset];
+
+        public int Count { get; }
+
+        public static bool operator ==(ReadOnlyListSegment<T> left, ReadOnlyListSegment<T> right)
+            => left.Equals(right);
+
+        public static bool operator !=(ReadOnlyListSegment<T> left, ReadOnlyListSegment<T> right)
+            => !left.Equals(right);
+
+        public static implicit operator ReadOnlyListSegment<T>(ReadOnlyCollection<T> source)
+        {
+            return new ReadOnlyListSegment<T>(source, 0, source?.Count ?? 0);
+        }
+
+        public static implicit operator ReadOnlyListSegment<T>(T[] source)
+        {
+            return new ReadOnlyListSegment<T>(source, 0, source?.Length ?? 0);
+        }
+
+        public readonly ReadOnlyListSegment<T> Slice(int start)
+        {
+            return new ReadOnlyListSegment<T>(
+                _source,
+                _offset + start,
+                Count - start);
+        }
+
+        public readonly ReadOnlyListSegment<T> Slice(int start, int length)
+        {
+            return new ReadOnlyListSegment<T>(
+                _source,
+                _offset + start,
+                length);
+        }
+
+        public readonly T[] ToArray()
+        {
+            if (Count == 0)
+            {
+                return Array.Empty<T>();
+            }
+
+            var result = new T[Count];
+            if (_source is IList<T> list)
+            {
+                list.CopyTo(result, _offset);
+                return result;
+            }
+
+            for (int i = Count - 1; i >= 0; i--)
+            {
+                result[i] = this[i];
+            }
+
+            return result;
+        }
+
+        public readonly Enumerator GetEnumerator() => new Enumerator(this);
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public bool Equals(ReadOnlyListSegment<T> other)
+        {
+            return Source == other.Source
+                && _offset == other._offset
+                && Count == other.Count;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is ReadOnlyListSegment<T> other && Equals(other);
+        }
+
+        public override int GetHashCode() => HashCode.Combine(_source, _offset, Count);
+
+        internal struct Enumerator : IEnumerator<T>
+        {
+            private readonly ReadOnlyListSegment<T> _segment;
+
+            private int _index;
+
+            public Enumerator(ReadOnlyListSegment<T> segment)
+            {
+                _segment = segment;
+                _index = -1;
+            }
+
+            public T Current => _segment[_index];
+
+            object? IEnumerator.Current => Current;
+
+            public void Dispose()
+            {
+            }
+
+            public bool MoveNext()
+            {
+                if (_index == -2)
+                {
+                    return false;
+                }
+
+                if (_index == -1)
+                {
+                    if (_segment.Count == 0)
+                    {
+                        return false;
+                    }
+
+                    _index++;
+                    return true;
+                }
+
+                if (_index >= _segment.Count - 1)
+                {
+                    _index = -2;
+                    return false;
+                }
+
+                _index++;
+                return true;
+            }
+
+            public void Reset() => _index = -1;
+        }
+    }
+}


### PR DESCRIPTION
In some method signatures like method declaration, `calli`, etc most of the `InvokeMemberExpression` isn't actually used so they end up being filled with jibberish.  This enables a syntax to cut that out of the signature and keep it readable.

Resolves #16 