### PR TITLE
Allow suffixing a type name with `+` to specify a pointer type

### DIFF
--- a/src/ILAssembler/SpecialTypes.cs
+++ b/src/ILAssembler/SpecialTypes.cs
@@ -4,6 +4,8 @@ namespace ILAssembler
     {
         public const string ByRef = "byref";
 
+        public const string Ref = "ref";
+
         public const string Pinned = "pinned";
 
         public const string Pointer = "pointer";

--- a/src/ILAssembler/TypeResolver.cs
+++ b/src/ILAssembler/TypeResolver.cs
@@ -24,7 +24,8 @@ namespace ILAssembler
                 return typeName.GetReflectionType() ?? throw ErrorTypeNotFound(typeName.Extent);
             }
 
-            if (genericTypeName.TypeName.FullName.Equals(SpecialTypes.ByRef, StringComparison.Ordinal))
+            if (genericTypeName.TypeName.FullName.Equals(SpecialTypes.ByRef, StringComparison.Ordinal)
+                || genericTypeName.TypeName.FullName.Equals(SpecialTypes.Ref, StringComparison.Ordinal))
             {
                 AssertSingleGenericArgument(genericTypeName);
                 var realType = Resolve(genericTypeName.GenericArguments[0]);

--- a/src/ILAssembler/TypeSignatureParser.cs
+++ b/src/ILAssembler/TypeSignatureParser.cs
@@ -69,7 +69,8 @@ namespace ILAssembler
         public override void VisitConvertExpression(ConvertExpressionAst convertExpressionAst)
         {
             ITypeName typeName = convertExpressionAst.Type.TypeName;
-            if (typeName.FullName.Equals(SpecialTypes.ByRef, StringComparison.Ordinal))
+            if (typeName.FullName.Equals(SpecialTypes.ByRef, StringComparison.Ordinal)
+                || typeName.FullName.Equals(SpecialTypes.Ref, StringComparison.Ordinal))
             {
                 if (!_allowByRef)
                 {


### PR DESCRIPTION
Also allow `ref` as an alias for `byref`.